### PR TITLE
I think now it works

### DIFF
--- a/cmd/ip.go
+++ b/cmd/ip.go
@@ -30,6 +30,7 @@ var ipCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		records := ip.PrivateIPs()
 		netutils.PrintIPs(records)
+		netutils.PrintPublicIP(ip.PublicIP())
 	},
 }
 

--- a/pkg/util/netutils/ip/ip.go
+++ b/pkg/util/netutils/ip/ip.go
@@ -17,7 +17,9 @@ limitations under the License.
 package ip
 
 import (
+	"io/ioutil"
 	"net"
+	"net/http"
 
 	"github.com/arush-sal/lot/pkg/util"
 )
@@ -75,4 +77,15 @@ func PrivateIPs() []Record {
 		records = append(records, r)
 	}
 	return records
+}
+
+// PublicIP return the public ip as returned by an external service
+func PublicIP() string {
+	resp, err := http.Get("http://myexternalip.com/raw")
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	publicIP, _ := ioutil.ReadAll(resp.Body)
+	return string(publicIP)
 }

--- a/pkg/util/netutils/netutils.go
+++ b/pkg/util/netutils/netutils.go
@@ -87,3 +87,12 @@ func PrintIPs(ipList []ip.Record) {
 	}
 	tw.Flush()
 }
+
+// PrintPublicIP prints the provided public IP addresses
+func PrintPublicIP(addr string) {
+	fmt.Println()
+	const format = "|%s\t|%s\n"
+	tw := new(tabwriter.Writer).Init(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintf(tw, format, "Public IP: ", addr)
+	tw.Flush()
+}


### PR DESCRIPTION
## Change Overview
Added support for the display of public ip
Currently uses myexternalip.com, should ideally be configurable to avoid dependency on one provider



<!-- Insert the description of the pull request-->

## Pull request type

Please check the type of change your PR introduces:
- [x] Enhancement
- [ ] Trival/Minor change
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation

## Issues

<!-- Insert the link to relevant issue/issues-->
- #11 

## Testing done

<!-- Include example how to run.-->
lot network ip

- [x] Manual
- [ ] Unit test
